### PR TITLE
support L4T 32.4.3 (JetPack 4.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # buildJetsonXavierKernel
-Scripts to help build the 4.9.140 kernel and modules onboard the Jetson AGX Xavier (L4T 32.3.1, JetPack 4.3). For previous versions, visit the 'tags' section.
+Scripts to help build the 4.9.140 kernel and modules onboard the Jetson AGX Xavier (L4T 32.4.3, JetPack 4.4). For previous versions, visit the 'tags' section.
 
-<em><strong>Note:</strong> The kernel source version must match the version of firmware flashed on the Jetson. For example, the source for the 4.9.140 kernel here is matched with L4T 32.3.1. This kernel compiled using this source tree will not work with newer versions or older versions of L4T, only 32.3.1.</em>
+<em><strong>Note:</strong> The kernel source version must match the version of firmware flashed on the Jetson. For example, the source for the 4.9.140 kernel here is matched with L4T 32.4.3. This kernel compiled using this source tree will not work with newer versions or older versions of L4T, only 32.4.3.</em>
 
 <em><strong>Note:</strong> You will probably only use these scripts to build and install modules. Even though there are scripts provided to build and copy the new kernel to the boot directory of the device, there is no effect. In newer versions of L4T, the kernel Image is actually signed and stored in a different partition on disk. The copyImage.sh script is legacy. In order to place the newly created Image, you will need to copy it to the correct place on the host and flash the eMMC. It is probably easier to build it on the host in the first place. The flash process on the host signs the Image, and copies it to the appropriate partition.</em>
 
 As of this writing, the "official" way to build the Jetson AGX Xavier kernel is to use a cross compiler on a Linux PC. This is an alternative which builds the kernel onboard the Jetson itself. These scripts will download the kernel source to the Jetson AGX Xavier, and then compile the kernel and selected modules. The newly compiled kernel can then be installed. The kernel sources and build objects consume ~3GB.
 
-These scripts are for building the kernel for the 64-bit L4T 32.3.1 (Ubuntu 18.04 based) operating system on the NVIDIA Jetson AGX Xavier. The scripts should be run directly after flashing the Jetson with L4T 32.3.1 from a host PC. There are six scripts:
+These scripts are for building the kernel for the 64-bit L4T 32.4.3 (Ubuntu 18.04 based) operating system on the NVIDIA Jetson AGX Xavier. The scripts may be run directly after flashing the Jetson with L4T 32.4.3 from a host PC. There are six scripts:
 
 <strong>getKernelSources.sh</strong>
 
@@ -50,6 +50,10 @@ Removes all of the kernel sources and compressed source files. You may want to m
 The copyImage.sh script copies the Image to the current device. If you are building the kernel on an external device, for example a SSD, you will probably want to copy the Image file over to the eMMC in the eMMC's /boot directory. The Jetson will usually try to boot from the eMMC before switching to a different device. Study the boot sequence of the Jetson to properly understand which Image file is being used.
 
 ### Release Notes
+
+October, 2020
+* vL4T32.4.3
+* L4T 32.4.3 (JetPack 4.4)
 
 January, 2020
 * Initial release

--- a/getKernelSources.sh
+++ b/getKernelSources.sh
@@ -4,7 +4,7 @@
 # MIT License
 
 JETSON_MODEL="AGX Xavier"
-L4T_TARGET="32.3.1"
+L4T_TARGET="32.4.3"
 SOURCE_TARGET="/usr/src"
 KERNEL_RELEASE="4.9"
 

--- a/scripts/getKernelSources.sh
+++ b/scripts/getKernelSources.sh
@@ -15,7 +15,7 @@ fi
 cd "$SOURCE_TARGET"
 echo "$PWD"
 # For this version, TX2 and Xavier have the same source files
-wget -N https://developer.nvidia.com/embedded/dlc/r32-3-1_Release_v1.0/Sources/T186/public_sources.tbz2
+wget -N https://developer.nvidia.com/embedded/L4T/r32_Release_v4.3/sources/T186/public_sources.tbz2
 # l4t-sources is a tbz2 file
 tar -xvf public_sources.tbz2  Linux_for_Tegra/source/public/kernel_src.tbz2 --strip-components=3
 tar -xvf kernel_src.tbz2
@@ -28,7 +28,7 @@ zcat /proc/config.gz > .config
 cp .config config.orig
 # Default to the current local version
 KERNEL_VERSION=$(uname -r)
-# For L4T 32.3 the kernel is 4.9.140-tegra ; 
+# For L4T 32.4.3 the kernel is 4.9.140-tegra ; 
 # Everything after '4.9.140' is the local version
 # This removes the suffix
 LOCAL_VERSION=${KERNEL_VERSION#$"4.9.140"}


### PR DESCRIPTION
Mainly updated the URL for public_sources.tbz2.
Also replaced 32.3.1 with 32.4.3.